### PR TITLE
Remove erroneous additional newline

### DIFF
--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -98,7 +98,7 @@ func passwordDecrypt(input []byte) error {
 	if err != nil {
 		return decErr(err)
 	}
-	_, err = os.Stdout.WriteString(plaintext + "\n")
+	_, err = os.Stdout.WriteString(plaintext)
 	return err
 }
 


### PR DESCRIPTION
When decrypting password encrypted messages, don't emit an additional
newline.  Fixes any tests related to password-encrypted messages,
e.g.: https://tests.sequoia-pgp.org/#Password-based_encryption