### PR TITLE
Change binary name in help and errors to gosop

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -21,7 +21,7 @@ var All = []*cli.Command{
 	{
 		Name:      "generate-key",
 		Usage:     "Generate a Secret Key",
-		UsageText: "sop-go generate-key [command options] [USERID...]",
+		UsageText: "gosop generate-key [command options] [USERID...]",
 		Flags: []cli.Flag{
 			noArmorFlag,
 		},
@@ -32,7 +32,7 @@ var All = []*cli.Command{
 	{
 		Name:      "extract-cert",
 		Usage:     "Extract a Certificate from a Secret Key",
-		UsageText: "sop-go extract-cert [command options]",
+		UsageText: "gosop extract-cert [command options]",
 		Flags: []cli.Flag{
 			noArmorFlag,
 		},
@@ -43,7 +43,7 @@ var All = []*cli.Command{
 	{
 		Name:      "sign",
 		Usage:     "Create a Detached Signature",
-		UsageText: "sop-go sign [command options] KEY [KEY...] < DATA",
+		UsageText: "gosop sign [command options] KEY [KEY...] < DATA",
 		Flags: []cli.Flag{
 			noArmorFlag,
 			asFlag,
@@ -55,7 +55,7 @@ var All = []*cli.Command{
 	{
 		Name:      "verify",
 		Usage:     "Verify a Detached Signature",
-		UsageText: "sop-go verify SIGNATURE CERTS [CERTS...] < DATA",
+		UsageText: "gosop verify SIGNATURE CERTS [CERTS...] < DATA",
 		Flags: []cli.Flag{
 			notBeforeFlag,
 			notAfterFlag,
@@ -67,7 +67,7 @@ var All = []*cli.Command{
 	{
 		Name:      "encrypt",
 		Usage:     "Encrypt a Message",
-		UsageText: "sop-go encrypt [command options] [CERTS...] < DATA",
+		UsageText: "gosop encrypt [command options] [CERTS...] < DATA",
 		Flags: []cli.Flag{
 			asFlag,
 			noArmorFlag,
@@ -81,7 +81,7 @@ var All = []*cli.Command{
 	{
 		Name:      "decrypt",
 		Usage:     "Decrypt a Message",
-		UsageText: "sop-go decrypt [command options] [KEY...] < CIPHERTEXT",
+		UsageText: "gosop decrypt [command options] [KEY...] < CIPHERTEXT",
 		Flags: []cli.Flag{
 			sessionKeyOutFlag,
 			sessionKeyFlag,
@@ -98,7 +98,7 @@ var All = []*cli.Command{
 	{
 		Name:      "armor",
 		Usage:     "Add ASCII Armor",
-		UsageText: "sop-go armor [command options] < DATA",
+		UsageText: "gosop armor [command options] < DATA",
 		Flags: []cli.Flag{
 			labelFlag,
 		},
@@ -109,7 +109,7 @@ var All = []*cli.Command{
 	{
 		Name:      "dearmor",
 		Usage:     "Remove ASCII Armor",
-		UsageText: "sop-go dearmor < DATA",
+		UsageText: "gosop dearmor < DATA",
 		Action: func(c *cli.Context) error {
 			return DearmorComm()
 		},

--- a/cmd/exit_codes.go
+++ b/cmd/exit_codes.go
@@ -6,13 +6,13 @@ import (
 
 // Error codes as defined in the draft, section 6.
 var (
-	Err3  = cli.Exit("Code 3: No acceptable signatures found (\"sop-go verify\")", 3)
-	Err13 = cli.Exit("Code 13: Asymmetric algorithm unsupported (\"sop-go encrypt\")", 13)
-	Err17 = cli.Exit("Code 17: Certificate not encryption-capable (\"sop-go encrypt\")", 17)
+	Err3  = cli.Exit("Code 3: No acceptable signatures found (\"gosop verify\")", 3)
+	Err13 = cli.Exit("Code 13: Asymmetric algorithm unsupported (\"gosop encrypt\")", 13)
+	Err17 = cli.Exit("Code 17: Certificate not encryption-capable (\"gosop encrypt\")", 17)
 	Err19 = cli.Exit("Missing required argument", 19)
-	Err23 = cli.Exit("Incomplete verification instructions (\"sop-go decrypt\")", 23)
-	Err29 = cli.Exit("Unable to decrypt (\"sop-go decrypt\")", 29)
-	Err31 = cli.Exit("Non-\"UTF-8\" password (\"sop-go encrypt\")", 31)
+	Err23 = cli.Exit("Incomplete verification instructions (\"gosop decrypt\")", 23)
+	Err29 = cli.Exit("Unable to decrypt (\"gosop decrypt\")", 29)
+	Err31 = cli.Exit("Non-\"UTF-8\" password (\"gosop encrypt\")", 31)
 	Err37 = cli.Exit("Unsupported option", 37)
 	Err41 = cli.Exit("Invalid data type (no secret key where \"KEY\" expected, etc)", 41)
 	Err53 = cli.Exit("Non-text input where text expected", 53)


### PR DESCRIPTION
The binary built is named gosop but in the help
and some errors it was referred to as sop-go.
