### PR TITLE
Update GopenPGP and set version 1.0.0

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ProtonMail/gopenpgp/v3/constants"
 )
 
-const VERSION = "2.0.0-alpha"
+const VERSION = "1.0.0"
 const SOP_VERSION = "~draft-dkg-openpgp-stateless-cli-06"
 
 // Version prints version information about gosop, and/or the

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/ProtonMail/gosop
 
 require (
-	github.com/ProtonMail/go-crypto v1.1.0-alpha.5
-	github.com/ProtonMail/gopenpgp/v3 v3.0.0-alpha.4
+	github.com/ProtonMail/go-crypto v1.1.0-beta.0
+	github.com/ProtonMail/gopenpgp/v3 v3.0.0-beta.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/urfave/cli/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ProtonMail/go-crypto v1.1.0-alpha.5 h1:XdtNqgUwXGClX/O+nSxecHUpgbsOGaUyv22y6p1laNk=
-github.com/ProtonMail/go-crypto v1.1.0-alpha.5/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/ProtonMail/go-crypto v1.1.0-beta.0 h1:9ZLo7gzqEbrSakeRM4L0jaHMuZSLrjoYBIdIwcBr4C4=
+github.com/ProtonMail/go-crypto v1.1.0-beta.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f/go.mod h1:gcr0kNtGBqin9zDW9GOHcVntrwnjrK+qdJ06mWYBybw=
-github.com/ProtonMail/gopenpgp/v3 v3.0.0-alpha.4 h1:4j0aFtErU3KHVGSZljPCTrtk0pUtyKyrDyc1eXARnPs=
-github.com/ProtonMail/gopenpgp/v3 v3.0.0-alpha.4/go.mod h1:D8EcScWNoL9mDQ1G8CNLgZeFdOF6R3o3nie6p7U8Zgw=
+github.com/ProtonMail/gopenpgp/v3 v3.0.0-beta.0 h1:7J2GzuKAJ4Th2fpRJzujbULEDQBAKXS4s0CKEDefo+Q=
+github.com/ProtonMail/gopenpgp/v3 v3.0.0-beta.0/go.mod h1:faQTqe6pVZ92OzsxNnm0L+ufMVs3t0DtA4irl00Lvig=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=

--- a/utils/profile.go
+++ b/utils/profile.go
@@ -92,6 +92,7 @@ func defaultProfile() *profile.Custom {
 		Name:                 "default",
 		SetKeyAlgorithm:      setKeyAlgorithm,
 		Hash:                 crypto.SHA256,
+		AeadEncryption:       &packet.AEADConfig{},
 		CipherEncryption:     packet.CipherAES256,
 		CompressionAlgorithm: packet.CompressionZLIB,
 		CompressionConfiguration: &packet.CompressionConfig{


### PR DESCRIPTION
- Update GopenPGP to v3.0.0-beta.0
- Enable SEIPDv2 in default profile (i.e., it is generated if key advertises it)
- Tag version 1.0.0