### PR TITLE
Improve profile handling

### DIFF
--- a/cmd/encrypt.go
+++ b/cmd/encrypt.go
@@ -28,7 +28,7 @@ func Encrypt(keyFilenames ...string) error {
 	if profile == nil {
 		return Err89
 	}
-	pgp := crypto.PGPWithProfile(profile)
+	pgp := crypto.PGPWithProfile(profile.PgpProfile)
 	builder := pgp.Encryption()
 	var err error
 	var input io.Reader = os.Stdin

--- a/cmd/generate_key.go
+++ b/cmd/generate_key.go
@@ -18,7 +18,7 @@ func GenerateKey(userIDs ...string) error {
 	if profile == nil {
 		return Err89
 	}
-	pgp := crypto.PGPWithProfile(profile)
+	pgp := crypto.PGPWithProfile(profile.PgpProfile)
 	// Generate key
 	gen := pgp.KeyGeneration()
 	for _, userID := range userIDs {
@@ -29,7 +29,7 @@ func GenerateKey(userIDs ...string) error {
 		gen.AddUserId(name, email)
 	}
 
-	key, err := gen.New().GenerateKey()
+	key, err := gen.New().GenerateKeyWithSecurity(profile.SecurityLevel)
 	if err != nil {
 		return kgErr(err)
 	}

--- a/cmd/list_profiles.go
+++ b/cmd/list_profiles.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
+	"strings"
 
 	"github.com/ProtonMail/gosop/utils"
 )
@@ -32,7 +32,13 @@ func ListProfiles(commands ...string) error {
 
 func printProfiles(profiles []*utils.SopProfile) error {
 	for id, profile := range profiles {
-		_, err := os.Stdout.WriteString(fmt.Sprintf("%s: %s\n", profile.Name, profile.Description))
+		aliases := ""
+		if len(profile.Names) > 2 {
+			aliases = fmt.Sprintf(" (aliases: %s)", strings.Join(profile.Names[1:], ", "))
+		} else if len(profile.Names) > 1 {
+			aliases = fmt.Sprintf(" (alias: %s)", profile.Names[1])
+		}
+		_, err := fmt.Printf("%s: %s%s\n", profile.Names[0], profile.Description, aliases)
 		if err != nil {
 			return listProfileErr(err)
 		}


### PR DESCRIPTION
- Return UNSUPPORTED_PROFILE error for unknown profiles
- Give the profiles more understandable names ("compatibility", "performance" and "security"), as per https://gitlab.com/dkg/openpgp-stateless-cli/-/merge_requests/37
- Implement a profile for Curve448 key generation under the name "security"
- Improve profile descriptions