### PR TITLE
docs(install): add x-cmd method to install gosop

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ implementations. For more information, please refer to the
 [specification](https://tools.ietf.org/html/draft-dkg-openpgp-stateless-cli-01).
 
 ### Install
+
+#### Instantly run gosop with x-cmd
+
+[x-cmd](https://www.x-cmd.com) is a lightweight cross-platform package manager implemented in posix shell. Quickly download and execute `gosop` with a single command: [x gosop](https://www.x-cmd.com/pkg/gosop)
+
+You can also install `gosop` in the user level without requiring root privileges.
+
+```
+x env use gosop
+```
+
+#### Build from source
+
 ```
 mkdir -p $GOPATH/src/github.com/ProtonMail/
 cd $GOPATH/src/github.com/ProtonMail/


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.. It helps you download gosop release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the gosop installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use gosop
  # or
  x gosop
  ```

- We wrote a [gosop introduction article and a demo](https://www.x-cmd.com/pkg/gosop)