### PR TITLE
go.mod version format changed form 1.22.0 to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 )
 
-go 1.22.0
+go 1.22


### PR DESCRIPTION
Fix go.mod version format:
```
go: errors parsing go.mod:
/src/github.com/ProtonMail/gosop/go.mod:18: invalid go version '1.22.0': must match format 1.23
```