### PR TITLE
Support `sop generate-key --signing-only`

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -37,6 +37,7 @@ var All = []*cli.Command{
 			noArmorFlag,
 			selectedProfileFlag,
 			keyPasswordFlag,
+			signingOnlyFlag,
 		},
 		Action: func(c *cli.Context) error {
 			return GenerateKey(c.Args().Slice()...)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -24,6 +24,7 @@ var (
 	verifyWith       cli.StringSlice
 	selectedProfile  string
 	keyPassword      string
+	signingOnly      bool
 )
 
 // All possible flags for commands
@@ -136,5 +137,10 @@ var (
 		Name:        "with-key-password",
 		Usage:       "--with-key-password=PASSWORD",
 		Destination: &keyPassword,
+	}
+	signingOnlyFlag = &cli.BoolFlag{
+		Name:        "signing-only",
+		Value:       false,
+		Destination: &signingOnly,
 	}
 )

--- a/cmd/generate_key.go
+++ b/cmd/generate_key.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ProtonMail/gosop/utils"
 
 	"github.com/ProtonMail/gopenpgp/v3/crypto"
+
+	"github.com/ProtonMail/go-crypto/openpgp/v2"
 )
 
 // GenerateKey creates a single default OpenPGP certificate with zero or more
@@ -34,6 +36,11 @@ func GenerateKey(userIDs ...string) error {
 		return kgErr(err)
 	}
 	defer key.ClearPrivateParams()
+
+	if signingOnly {
+		// Remove the encryption subkey
+		key.GetEntity().Subkeys = []v2.Subkey{}
+	}
 
 	// Lock key if required
 	if keyPassword != "" {


### PR DESCRIPTION
This is a temporary hack until we have https://github.com/ProtonMail/go-crypto/pull/293 (and a corresponding option in gopenpgp). We remove the encryption subkey after the key has been generated.

Resolves https://github.com/ProtonMail/gosop/issues/43.