### PR TITLE
Properly report issuer fingerprint, if available

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -81,12 +81,15 @@ func writeVerificationToOutput(out *os.File, result *crypto.VerifyResult) error 
 			mode = "mode:binary"
 		}
 		creationTime := signature.Signature.CreationTime
-		fingerprintSign := signature.SignedBy.GetFingerprintBytes()
-		fingerprintPrimarySign := signature.SignedBy.GetFingerprintBytes()
+		issuerFingerprint := signature.Signature.IssuerFingerprint
+		if issuerFingerprint == nil {
+			issuerFingerprint = signature.SignedBy.GetFingerprintBytes()
+		}
+		issuerPrimaryFingerprint := signature.SignedBy.GetFingerprintBytes()
 		ver = utils.VerificationString(
 			creationTime,
-			fingerprintSign,
-			fingerprintPrimarySign,
+			issuerFingerprint,
+			issuerPrimaryFingerprint,
 			mode,
 		)
 		if _, err := out.WriteString(ver + "\n"); err != nil {


### PR DESCRIPTION
Rather than reporting the primary key fingerprint twice, report the issuer fingerprint of the (sub)key that signed the signature (as required by the sop spec) if the issuer fingerprint subpacket is available.